### PR TITLE
Reducida la instalacion a un solo comando "npm run start"

### DIFF
--- a/.autorunning.sh
+++ b/.autorunning.sh
@@ -1,5 +1,0 @@
-if [ -d "./node_modules/" ]; then
-  gulp
-else
-  npm install && gulp
-fi

--- a/.autorunning.sh
+++ b/.autorunning.sh
@@ -1,0 +1,5 @@
+if [ -d "./node_modules/" ]; then
+  gulp
+else
+  npm install && gulp
+fi

--- a/.start.js
+++ b/.start.js
@@ -1,0 +1,12 @@
+const util = require("util");
+const stat = require('fs').stat;
+const exec = require('child_process').exec;
+
+(function install() {
+    stat('./node_modules/', (err, stats) => {
+      if (err) {
+        console.log("Instalando las dependencias, por fabor aguarde....");
+        exec('npm install');
+      }
+    })
+  })();

--- a/.start.js
+++ b/.start.js
@@ -1,4 +1,3 @@
-const util = require("util");
 const stat = require('fs').stat;
 const exec = require('child_process').exec;
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple scafolding for statics web projects",
   "main": "gulpfile.babel.js",
   "scripts": {
+    "start": "sh ./.autorunning.sh",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Alvaro Felipe",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Simple scafolding for statics web projects",
   "main": "gulpfile.babel.js",
   "scripts": {
-    "start": "sh ./.autorunning.sh",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node .start.js"
   },
   "author": "Alvaro Felipe",
   "license": "GPL-2.0",


### PR DESCRIPTION
Hola, he agregado un archivo de script que comprueba si existe el directorio *node_modules* y si existe arranca automáticamente *gulp*, en caso contrario ejecuta el comando *npm install* y luego nuevamente ejecuta *gulp*, de este modo al descargar el repositorio solamente hace falta hacer *"npm run start"* para que todo funcione.