### PR TITLE
Agrega scripts de Gulp a la sección de scripts de npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "description": "Simple scafolding for statics web projects",
   "main": "gulpfile.babel.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp",
+    "pug": "gulp pug",
+    "scripts": "gulp scripts",
+    "images": "gulp images",
+    "sitemap": "gulp sitemap"
   },
   "author": "Alvaro Felipe",
   "license": "GPL-2.0",


### PR DESCRIPTION
Agrega scripts de Gulp a la sección de scripts de npm para poder ejecutarlos con el comando npm run  y npm run-script y facilita una lectura de los scripts disponibles sin tener que acceder al gulpfile